### PR TITLE
Feat: Check for custom course fields

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -32,7 +32,11 @@ defined('MOODLE_INTERNAL') || die();
  * @param context $context The category context
  */
 function tool_coursefields_extend_navigation_category_settings($navigation, $context) {
-    if (has_capability('tool/coursefields:setfields', $context)) {
+    // First check if custom course fields (ccf) are available at all.
+    $ccfhandler = core_course\customfield\course_handler::create();
+    $hasccf = !empty($ccfhandler->get_categories_with_fields());
+
+    if ($hasccf && has_capability('tool/coursefields:setfields', $context)) {
          $navigation->add_node(
              navigation_node::create(
                  get_string('setfields', 'tool_coursefields'),

--- a/tests/behat/tool_coursefields_nofields.feature
+++ b/tests/behat/tool_coursefields_nofields.feature
@@ -16,8 +16,8 @@ Feature: The course fields tool does not allow a manager to set custom course fi
       | Course 2 | C2        | CAT2     | 1       | 1546300800 |
       | Course 3 | C3        | CAT3     | 1       | 1546300800 |
 
-   Scenario: Manager is not able to use the course fields tool if there are not any course field categories
-     When I log in as "admin"
-     And I am on course index
-     And I follow "Category 1"
-     Then "Set course fields" "link" should not exist in current page administration
+  Scenario: Manager is not able to use the course fields tool if there are not any course field categories
+    When I log in as "admin"
+    And I am on course index
+    And I follow "Category 1"
+    Then "Set course fields" "link" should not exist in current page administration

--- a/tests/behat/tool_coursefields_nofields.feature
+++ b/tests/behat/tool_coursefields_nofields.feature
@@ -1,0 +1,23 @@
+@tool @tool_coursefields
+Feature: The course fields tool does not allow a manager to set custom course fields before creating custom course field categories
+  In order to use the tool
+  As a manager
+  I need to create custom course fields first
+
+  Background:
+    Given the following "categories" exist:
+      | name       | category | idnumber | visible |
+      | Category 1 | 0        | CAT1     | 0       |
+      | Category 2 | CAT1     | CAT2     | 0       |
+      | Category 3 | 0        | CAT3     | 0       |
+    And the following "courses" exist:
+      | fullname | shortname | category | visible | startdate  |
+      | Course 1 | C1        | CAT2     | 1       | 1546300800 |
+      | Course 2 | C2        | CAT2     | 1       | 1546300800 |
+      | Course 3 | C3        | CAT3     | 1       | 1546300800 |
+
+   Scenario: Manager is not able to use the course fields tool if there are not any course field categories
+     When I log in as "admin"
+     And I am on course index
+     And I follow "Category 1"
+     Then "Set course fields" "link" should not exist in current page administration


### PR DESCRIPTION
Hi Alex,

this is the PR for the feature we talked about, with the changes you recommended:

- the check is now performed when the node is added to cat-settings
- a behat test checking the check

This improves the case when the tool is installed and there are no custom course fields defined yet
– however: I am simply checking against _get_categories_with_fields()_ but do not look if there are any fields in the categories. 

Consequently there is the case of having ccf-categories without ccf-fields defined,
in which the user is prompted again with an empty form.

Do you want to adress this here (e.g. iterating over the categories every time? (which i dont like))
or maybe as a new feat for index.php (e.g. finding at least one ccf there and/or link to admin settings)
or do you think it is not that relevant?

Best regards
Christian